### PR TITLE
Add a value source that reads from a json file on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ functions) that acquire value data, and calculators that take
 undeployed value data, deployed value data, and calculates the diffrence
 between them. 
 
+#### `getvalues` Management Command
+
+The Porchlight API includes a management command to pull data from the
+configured sources for specified repositories or all repositories. This
+command is suitable for `cron` or similar periodic task systems.
+
+For all repositories:
+
+```shell
+$ python manage.py getvalues
+...
+Got datapoint for https://github.com/cfpb/porchlight: 398
+...
+```
+
+For a specific repository:
+
+```shell
+$ python manage.py getvalues
+Got datapoint for https://github.com/cfpb/porchlight: 398
+```
+
 #### <a name="value-sources"></a> Value Sources
 
 A value source is a Python callable that takes a project url (the

--- a/porchlight/local_settings_template.py
+++ b/porchlight/local_settings_template.py
@@ -1,0 +1,6 @@
+
+
+
+# Set this if you want to load a JSON file from a specific path.
+PORCHLIGHT_JSON_FILE = ''
+

--- a/porchlight/settings.py
+++ b/porchlight/settings.py
@@ -99,3 +99,9 @@ REST_FRAMEWORK = {
     )
 }
 
+
+try:
+    from porchlight.local_settings import *
+except ImportError:
+    pass
+

--- a/porchlightapi/management/commands/getvalues.py
+++ b/porchlightapi/management/commands/getvalues.py
@@ -9,14 +9,21 @@ class Command(BaseCommand):
     help = 'Fetch value data points for the given repositories'
 
     def handle(self, *args, **options):
-        for repository_url in args:
-            try:
-                repository = Repository.objects.get(url=repository_url)
-            except Repository.DoesNotExist:
-                raise CommandError('Repository {} is not in Porchlight'.format(repository_url))
 
+        repositories = []
+        if len(args) > 0:
+            for repository_url in args:
+                try:
+                    repositories.append(Repository.objects.get(url=repository_url))
+                except Repository.DoesNotExist:
+                    raise CommandError('Repository {} is not in Porchlight'.format(repository_url))
+
+        else:
+            repositories = Repository.objects.all()
+
+        for repository in repositories:
             datapoint = ValueDataPoint.objects.create_datapoint(repository)
 
-            self.stdout.write('Got datapoint for {}: {}'.format(repository_url, datapoint.value))
+            self.stdout.write('Got datapoint for {}: {}'.format(repository.url, datapoint.value))
 
 

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -15,6 +15,7 @@ PORCHLIGHT_UNDEPLOYED_SOURCES = getattr(settings,
 
 PORCHLIGHT_DEPLOYED_SOURCES_DEFAULT = (
     ('porchlightapi.sources.random_source', 'Random Source'),
+    ('porchlightapi.sources.json_file_source', 'JSON File (defined in settings.py)'),
 )
 PORCHLIGHT_DEPLOYED_SOURCES = getattr(settings,
                                       'PORCHLIGHT_DEPLOYED_SOURCES',

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -28,5 +28,10 @@ PORCHLIGHT_VALUE_CALCULATOR = getattr(settings,
                                       'PORCHLIGHT_VALUE_CALCULATOR',
                                       PORCHLIGHT_VALUE_CALCULATOR_DEFAULT)
 
+PORCHLIGHT_JSON_FILE_DEFAULT = 'repos.json'
+PORCHLIGHT_JSON_FILE = getattr(settings,
+                               'PORCHLIGHT_JSON_FILE',
+                               PORCHLIGHT_JSON_FILE_DEFAULT)
+
 
 

--- a/porchlightapi/sources/__init__.py
+++ b/porchlightapi/sources/__init__.py
@@ -1,7 +1,8 @@
-
+# -*- coding: utf-8 -*-
 
 from .calculators import difference_value_calculator
 from .calculators import undeployed_value_only_calculator
 
 from .rand import random_source
 from .github import github_source
+from .json_file import json_file_source

--- a/porchlightapi/sources/github.py
+++ b/porchlightapi/sources/github.py
@@ -4,6 +4,86 @@ from urlparse import urlparse, urlunparse
 import dateutil.parser
 import requests
 
+def github_data(project_url, branch='master', commit=''):
+    """
+    Fetch data from Github that's relevent to Porchlight.
+    This function is meant to be used by all sources that might need to
+    access Github data.
+    """
+    project_url_parts = urlparse(project_url)
+
+    # If this is a Github URL, use api.github.com. Otherwise use /api/v3/
+    api_url = None
+    if project_url_parts.netloc == 'github.com':
+        api_url = project_url_parts._replace(
+            netloc='api.' + project_url_parts.netloc)
+    else:
+        api_url = project_url_parts._replace(
+            path='/api/v3')
+
+    # Construct an API URL for the repository itself. This API call is only used
+    # to get the repo size, which is about the only metric we can get from
+    # the Github API to scale the file changes (below) relative to the
+    # repository.
+    repo_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + project_url_parts.path)
+    repo_url = urlunparse(repo_url_parts)
+    repo_response = requests.get(repo_url)
+    repo_size = repo_response.json()['size']
+
+    # If we didn't get a specific commit, look up the branch and use that.
+    commit_url = None
+    if commit == '':
+        # Get the specified branch so we can lookup the latest commit SHA.
+        # We'll construct an API URL based on the project URL.
+        branch_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + project_url_parts.path + '/branches/' + branch)
+        branch_url = urlunparse(branch_url_parts)
+        branch_response = requests.get(branch_url)
+
+        # Note: the branch API call above gets us *some* of the commit info, but not
+        # all. We don't get files data, for example, which is important for the
+        # value calculation below.
+        commit = branch_response.json()['commit']['sha']
+        commit_url = branch_response.json()['commit']['url']
+    else:
+        commit_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + project_url_parts.path + '/commits/' + commit)
+        commit_url = urlunparse(commit_url_parts)
+
+    commit_response = requests.get(commit_url)
+    commit_json = commit_response.json()
+    commit_num_files = len(commit_json['files'])
+
+    # Pyhton date formatting doesn't give any good option for parsing ISO-8601
+    # dates that include a 'Z' (Zulu) for UTC instead of simply +0000. According
+    # to the Github API documentation, Github returns ISO-8601 with the full
+    # timezone offset. However, the results I'm seeing from Github all represent
+    # the timezone as 'Z'. To be safe, not make assumptions, and not add
+    # unnecessary complexity, `dateutil.parser` is being used to parse date
+    # strings.
+    commit_date_string = commit_json['commit']['committer']['date']
+    commit_date = dateutil.parser.parse(commit_date_string)
+
+    # This is the useful information to us about how valuable this commit might
+    # be. This is used below in the value calcualtion.
+    commit_additions = 0
+    commit_deletions = 0
+    commit_changes = 0
+    for file in commit_json['files']:
+        commit_additions = commit_additions + file['additions']
+        commit_deletions = commit_deletions + file['deletions']
+        commit_changes = commit_changes + file['changes']
+
+    return {'repo_size': repo_size,
+            'commit': commit,
+            'commit_num_files': commit_num_files,
+            'commit_date': commit_date,
+            'commit_additions': commit_additions,
+            'commit_deletions': commit_deletions,
+            'commit_changes': commit_changes,}
+
+
 def github_source(project_url, branch='master'):
     """
     Github value source for Porchlight.
@@ -13,62 +93,15 @@ def github_source(project_url, branch='master'):
 
     Based on Github API documentation here: https://developer.github.com/v3/git/commits/
     """
-    project_url_parts = urlparse(project_url)
-
-    # Construct an API URL for the repository itself. This API call is only used
-    # to get the repo size, which is about the only metric we can get from
-    # the Github API to scale the file changes (below) relative to the
-    # repository.
-    repo_url_parts = project_url_parts._replace(
-        netloc='api.' + project_url_parts.netloc,
-        path='/repos' + project_url_parts.path)
-    repo_url = urlunparse(repo_url_parts)
-    repo_response = requests.get(repo_url)
-    repo_size = repo_response.json()['size']
-
-    # Get the specified branch so we can lookup the latest commit SHA.
-    # We'll construct an API URL based on the project URL.
-    branch_url_parts = project_url_parts._replace(
-        netloc='api.' + project_url_parts.netloc,
-        path='/repos' + project_url_parts.path + '/branches/' + branch)
-    branch_url = urlunparse(branch_url_parts)
-    branch_response = requests.get(branch_url)
-
-    # Note: the branch API call above gets us *some* of the commit info, but not
-    # all. We don't get files data, for example, which is important for the
-    # value calculation below.
-    last_commit_sha = branch_response.json()['commit']['sha']
-    last_commit_url = branch_response.json()['commit']['url']
-    last_commit_response = requests.get(last_commit_url)
-    last_commit_json = last_commit_response.json()
-    last_commit_num_files = len(last_commit_json['files'])
-
-    # Pyhton date formatting doesn't give any good option for parsing ISO-8601
-    # dates that include a 'Z' (Zulu) for UTC instead of simply +0000. According
-    # to the Github API documentation, Github returns ISO-8601 with the full
-    # timezone offset. However, the results I'm seeing from Github all represent
-    # the timezone as 'Z'. To be safe, not make assumptions, and not add
-    # unnecessary complexity, `dateutil.parser` is being used to parse date
-    # strings.
-    last_commit_date_string = last_commit_json['commit']['committer']['date']
-    last_commit_date = dateutil.parser.parse(last_commit_date_string)
-
-    # This is the useful information to us about how valuable this commit might
-    # be. This is used below in the value calcualtion.
-    last_commit_additions = 0
-    last_commit_deletions = 0
-    last_commit_changes = 0
-    for file in last_commit_json['files']:
-        last_commit_additions = last_commit_additions + file['additions']
-        last_commit_deletions = last_commit_deletions + file['deletions']
-        last_commit_changes = last_commit_changes + file['changes']
+    github_dict = github_data(project_url, branch=branch)
 
     # XXX: I am skeptical that this formula is useful. It includes nothing in
     # relation to the project size, we may want to value deletions as much as
     # additions, rather than presuming they have negative valuye, etc...
-    value = last_commit_additions - last_commit_deletions + last_commit_changes
+    value = github_dict['commit_additions'] - \
+            github_dict['commit_deletions'] + \
+            github_dict['commit_changes']
 
-    return (last_commit_sha, last_commit_date, value)
-
+    return (github_dict['commit'], github_dict['commit_date'], value)
 
 

--- a/porchlightapi/sources/github.py
+++ b/porchlightapi/sources/github.py
@@ -16,7 +16,8 @@ def github_data(project_url, branch='master', commit=''):
     api_url = None
     if project_url_parts.netloc == 'github.com':
         api_url = project_url_parts._replace(
-            netloc='api.' + project_url_parts.netloc)
+            netloc='api.' + project_url_parts.netloc,
+            path='')
     else:
         api_url = project_url_parts._replace(
             path='/api/v3')

--- a/porchlightapi/sources/json_file.py
+++ b/porchlightapi/sources/json_file.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from urlparse import urlparse, urlunparse
+
+import json
+import dateutil.parser
+
+from porchlightapi import settings
+from .github import github_data
+
+def json_file_source(project_url):
+    """
+    A JSON file on the server includes the repo url and a commit SHA.
+    Given a URL, look it up in that file, and then fetch the information
+
+    we need about the commit from Github.
+
+    Fetch the latest commit date, SHA, and lines from Github for the
+    given project URL.
+
+    Based on Github API documentation here: https://developer.github.com/v3/git/commits/
+    """
+
+    # Open the file
+    repos = json.load(open(settings.PORCHLIGHT_JSON_FILE))
+
+    # Lookup the repository URL
+    repo_dict = next((item for item in repos if item[u'repo'].lower().startswith(project_url)), None)
+
+    # Get the commit SHA
+    commit = repo_dict['commit']
+    date_string = repo_dict['date']
+    date_string = repo_dict['date']
+    date = dateutil.parser.parse(date_string)
+
+    # Lookup the data in Github
+    github_dict = github_data(project_url, commit=commit)
+
+    # XXX: I am skeptical that this formula is useful. It includes nothing in
+    # relation to the project size, we may want to value deletions as much as
+    # additions, rather than presuming they have negative valuye, etc...
+    value = github_dict['commit_additions'] - \
+            github_dict['commit_deletions'] + \
+            github_dict['commit_changes']
+
+    return (commit, date, value)
+

--- a/porchlightapi/tests.py
+++ b/porchlightapi/tests.py
@@ -119,33 +119,31 @@ class ValueDataPointManagerTestCase(TestCase):
 
 import datetime
 from porchlightapi.sources import github_source
+from porchlightapi.sources import json_file_source
 
 class DataSourceTestCase(TestCase):
 
-    @mock.patch("requests.get")
-    def test_github_source(self, mock_request_get):
-        # Test that our Github source function correctly constructs URLs by
-        # mocking requests.get()
-
-        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
-                                      minute=44, second=20, tzinfo=tz.tzutc())
+    def setUp(self):
+        """
+        Set up the mock request responses for Github.
+        """
 
         # First call, to /repos/porchlight is only interested in size
-        mock_repo_response = mock.MagicMock()
-        mock_repo_response.json.return_value = {u'size': 1619,}
+        self.mock_repo_response = mock.MagicMock()
+        self.mock_repo_response.json.return_value = {u'size': 1619,}
 
         # Second call to /repos/porchlight/branches/master is used to
         # get last commit SHA and URL
-        mock_branches_response = mock.MagicMock()
-        mock_branches_response.json.return_value = {u'commit':
+        self.mock_branches_response = mock.MagicMock()
+        self.mock_branches_response.json.return_value = {u'commit':
                 {u'sha': u'130df1874519c11a79ac4a2e3e6671a165860441',
                  u'url': u'https://api.github.com/repos/cfpb/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441'}
             }
 
         # Third call is to the commit itself, /repos/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441
         # is used to get the date and file data
-        mock_commit_response = mock.MagicMock()
-        mock_commit_response.json.return_value = {
+        self.mock_commit_response = mock.MagicMock()
+        self.mock_commit_response.json.return_value = {
             u'commit': {u'committer': {u'date': u'2015-01-26 21:44:20Z',},},
             u'files':[
                 {'additions': 1, 'deletions': 2, 'changes':3},
@@ -154,18 +152,57 @@ class DataSourceTestCase(TestCase):
             ]
         }
 
+    @mock.patch("requests.get")
+    def test_github_source(self, mock_request_get):
+        # Test that our Github source function correctly constructs URLs by
+        # mocking requests.get()
+
         mock_request_get.side_effect = [
-            mock_repo_response,
-            mock_branches_response,
-            mock_commit_response
+            self.mock_repo_response,
+            self.mock_branches_response,
+            self.mock_commit_response
         ]
 
         porchlight_url = 'https://github.com/cfpb/porchlight'
 
         source_tuple = github_source(porchlight_url)
 
+        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
+                                      minute=44, second=20, tzinfo=tz.tzutc())
+
         self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
         self.assertEqual(source_tuple[1], test_date)
         self.assertEqual(source_tuple[2], 15)
 
+
+    @mock.patch("__builtin__.open")
+    @mock.patch("json.load")
+    @mock.patch("requests.get")
+    def test_repo_json(self, mock_request_get, mock_json_load, mock_open):
+        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
+                                      minute=44, second=20, tzinfo=tz.tzutc())
+
+        # We just want to ignore the call to open() altogether
+        mock_open.return_value = None
+
+        # Mock the contents of the json file.
+        mock_json_load.return_value = [{u'commit': '130df1874519c11a79ac4a2e3e6671a165860441',
+                                        u'repo': 'https://github.com/CFPB/porchlight.git',
+                                        u'date': u'Mon Jan 26 21:44:20 UTC 2015'},]
+
+        # Mock the requests.get() calls to github API. This differs from
+        # github_source() above because we get the commit SHA from the
+        # json data rather than from the tip of a branch.
+        mock_request_get.side_effect = [
+            self.mock_repo_response,
+            self.mock_commit_response
+        ]
+
+        porchlight_url = 'https://github.com/cfpb/porchlight'
+
+        source_tuple = json_file_source(porchlight_url)
+
+        self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
+        self.assertEqual(source_tuple[1], test_date)
+        self.assertEqual(source_tuple[2], 15)
 


### PR DESCRIPTION
The `json_file_source` uses a setting in settings.py (or local_settings.py) called `PORCHLIGHT_JSON_FILE` that should be set to a filesystem path where a json file can be found. If a Porchlight repository is configured to use `JSON File` as its source, Porchlight will attempt to find the repository's URL in that file, along with a date and commit SHA. The commit SHA will then be looked up on Github (both public and Enterprise) to find the relevant data about the commit. When combined with the Github data source, this should allow comparison between undeployed data on Github and deployed data that is associated with a git commit that's also on Github.
