### PR TITLE
Make deployment datetimes/identifiers optional

### DIFF
--- a/porchlightapi/migrations/0003_auto_20150206_1253.py
+++ b/porchlightapi/migrations/0003_auto_20150206_1253.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('porchlightapi', '0002_auto_20150126_1925'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='valuedatapoint',
+            options={'ordering': ('-created',)},
+        ),
+        migrations.AlterField(
+            model_name='repository',
+            name='deployed_value_source',
+            field=models.CharField(help_text=b'This is a Python callable, defined in settings.py, that provides the deployed value for this repository.', max_length=200, verbose_name=b'Deployed Value Source', choices=[(b'porchlightapi.sources.random_source', b'Random Source'), (b'porchlightapi.sources.json_file_source', b'JSON File (defined in settings.py)')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='repository',
+            name='undeployed_value_source',
+            field=models.CharField(help_text=b'This is a Python callable, defined in settings.py, that provides the undeployed value for this repository.', max_length=200, verbose_name=b'Undeployed Value Source', choices=[(b'porchlightapi.sources.random_source', b'Random Source'), (b'porchlightapi.sources.github_source', b'Github Source')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='repository',
+            name='value_calculator',
+            field=models.CharField(help_text=b'This is a Python callable, defined in settings.py, that calculates the total unshipped value for this repository.', max_length=200, verbose_name=b'Value Calculator', choices=[(b'porchlightapi.sources.difference_value_calculator', b'Difference Between Undeployed and Deployed Value'), (b'porchlightapi.sources.undeployed_value_only_calculator', b'Undeployed Value Only'), (b'porchlightapi.sources.incremental_value_calculator', b'Incremental Undeployed Value (adds new value to prior value)')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='valuedatapoint',
+            name='deployed_datetime',
+            field=models.DateTimeField(null=True, verbose_name=b'Deployment Date/Time', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/porchlightapi/migrations/0004_auto_20150206_1257.py
+++ b/porchlightapi/migrations/0004_auto_20150206_1257.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('porchlightapi', '0003_auto_20150206_1253'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='valuedatapoint',
+            name='deployed_identifier',
+            field=models.CharField(max_length=40, null=True, verbose_name=b'Deployment Identifier (Commit SHA)', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/porchlightapi/models.py
+++ b/porchlightapi/models.py
@@ -152,7 +152,7 @@ class ValueDataPoint(models.Model):
     undeployed_value = models.IntegerField('Deployed Value', default=0)
 
     deployed_identifier = models.CharField('Deployment Identifier (Commit SHA)',
-                                           max_length=40)
+                                           max_length=40, blank=True, null=True)
     deployed_datetime = models.DateTimeField('Deployment Date/Time', blank=True, null=True)
     deployed_value = models.IntegerField('Deployed Value', default=0)
 

--- a/porchlightapi/models.py
+++ b/porchlightapi/models.py
@@ -153,7 +153,7 @@ class ValueDataPoint(models.Model):
 
     deployed_identifier = models.CharField('Deployment Identifier (Commit SHA)',
                                            max_length=40)
-    deployed_datetime = models.DateTimeField('Deployment Date/Time')
+    deployed_datetime = models.DateTimeField('Deployment Date/Time', blank=True, null=True)
     deployed_value = models.IntegerField('Deployed Value', default=0)
 
     value = models.IntegerField('Unshipped Value Calculation', default=0)

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -24,7 +24,7 @@ PORCHLIGHT_DEPLOYED_SOURCES = getattr(settings,
 PORCHLIGHT_VALUE_CALCULATOR_DEFAULT = (
     ('porchlightapi.sources.difference_value_calculator', 'Difference Between Undeployed and Deployed Value'),
     ('porchlightapi.sources.undeployed_value_only_calculator', 'Undeployed Value Only'),
-    ('porchlightapi.sources.incremental_undeployed_value_calculator', 'Incremental Undeployed Value (adds new value to prior value)'),
+    ('porchlightapi.sources.incremental_value_calculator', 'Incremental Undeployed Value (adds new value to prior value)'),
 )
 PORCHLIGHT_VALUE_CALCULATOR = getattr(settings,
                                       'PORCHLIGHT_VALUE_CALCULATOR',


### PR DESCRIPTION
Simple change to allow optional deployment datetimes and identifiers. You don't have to have been deployed to have unshipped value.
