### PR TITLE
Disable pagination of datapoints

### DIFF
--- a/porchlightapi/serializers.py
+++ b/porchlightapi/serializers.py
@@ -23,7 +23,10 @@ class PaginatedValueDataPointSerializer(PaginationSerializer):
         object_serializer_class = ValueDataPointSerializer
 
 class RepositorySerializer(serializers.HyperlinkedModelSerializer):
-    datapoints = serializers.SerializerMethodField('paginated_datapoints')
+    # Uncommment this line and comment the following line if you want paginated
+    # datapoints.
+    # datapoints = serializers.SerializerMethodField('paginated_datapoints')
+    datapoints = ValueDataPointSerializer(many=True)
 
     class Meta:
         model = Repository

--- a/porchlightapi/views.py
+++ b/porchlightapi/views.py
@@ -52,7 +52,7 @@ class ValueDataPointViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (filters.SearchFilter,)
     search_fields = ('repository__name', 'repository__project', 'repository__url')
 
-    paginate_by = 10
-    paginate_by_param = 'limit'
+    # paginate_by = 10
+    # paginate_by_param = 'limit'
 
 


### PR DESCRIPTION
This PR disables pagination of datapoints in both the json returned by the repository endpoint and the datapoints endpoint.
