### PR TITLE
Add Value Source for Github Tags 

### DIFF
--- a/porchlightapi/admin.py
+++ b/porchlightapi/admin.py
@@ -15,8 +15,11 @@ admin.site.register(Repository, RepositoryAdmin)
 class ValueDataPointAdmin(admin.ModelAdmin):
     # All the fields are readonly
     list_display = ('created',
+                    'repository',
                     'undeployed_datetime',
+                       'undeployed_identifier',
                     'deployed_datetime',
+                       'deployed_identifier',
                     'value')
     readonly_fields = ('repository',
                        'created',
@@ -27,6 +30,7 @@ class ValueDataPointAdmin(admin.ModelAdmin):
                        'deployed_datetime',
                        'deployed_value',
                        'value',)
+    list_filter = ('repository',)
 
     # We don't allow admin to add or change data points. Only view.
     def has_add_permission(self, request):

--- a/porchlightapi/models.py
+++ b/porchlightapi/models.py
@@ -51,6 +51,9 @@ class Repository(models.Model):
                                 max_length=200,
                                 help_text='This is a Python callable, defined in settings.py, that calculates the total unshipped value for this repository.')
 
+    def __unicode__(self):
+        return self.name
+
     def deployed_value(self):
         """
         Get and run the deployed_value_source.

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -7,7 +7,7 @@ from django.conf import settings
 # human-readable descriptor.
 PORCHLIGHT_UNDEPLOYED_SOURCES_DEFAULT = (
     ('porchlightapi.sources.random_source', 'Random Source'),
-    ('porchlightapi.sources.github_commit_source', 'Github Source'),
+    ('porchlightapi.sources.github_commit_source', 'Github Commit Source'),
 )
 PORCHLIGHT_UNDEPLOYED_SOURCES = getattr(settings,
                                         'PORCHLIGHT_UNDEPLOYED_SOURCES',
@@ -15,7 +15,7 @@ PORCHLIGHT_UNDEPLOYED_SOURCES = getattr(settings,
 
 PORCHLIGHT_DEPLOYED_SOURCES_DEFAULT = (
     ('porchlightapi.sources.random_source', 'Random Source'),
-    ('porchlightapi.sources.github_tag_source', 'Github Source'),
+    ('porchlightapi.sources.github_tag_source', 'Github Tags Source'),
     ('porchlightapi.sources.json_file_source', 'JSON File (defined in settings.py)'),
 )
 PORCHLIGHT_DEPLOYED_SOURCES = getattr(settings,

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -36,6 +36,7 @@ PORCHLIGHT_JSON_FILE = getattr(settings,
                                'PORCHLIGHT_JSON_FILE',
                                PORCHLIGHT_JSON_FILE_DEFAULT)
 
+# Auth format is a 2-tuple: ('<username>', '<authorization token>')
 PORCHLIGHT_GITHUB_AUTH_DEFAULT = None
 PORCHLIGHT_GITHUB_AUTH = getattr(settings,
                                  'PORCHLIGHT_GITHUB_AUTH',

--- a/porchlightapi/settings.py
+++ b/porchlightapi/settings.py
@@ -7,7 +7,7 @@ from django.conf import settings
 # human-readable descriptor.
 PORCHLIGHT_UNDEPLOYED_SOURCES_DEFAULT = (
     ('porchlightapi.sources.random_source', 'Random Source'),
-    ('porchlightapi.sources.github_source', 'Github Source'),
+    ('porchlightapi.sources.github_commit_source', 'Github Source'),
 )
 PORCHLIGHT_UNDEPLOYED_SOURCES = getattr(settings,
                                         'PORCHLIGHT_UNDEPLOYED_SOURCES',
@@ -15,6 +15,7 @@ PORCHLIGHT_UNDEPLOYED_SOURCES = getattr(settings,
 
 PORCHLIGHT_DEPLOYED_SOURCES_DEFAULT = (
     ('porchlightapi.sources.random_source', 'Random Source'),
+    ('porchlightapi.sources.github_tag_source', 'Github Source'),
     ('porchlightapi.sources.json_file_source', 'JSON File (defined in settings.py)'),
 )
 PORCHLIGHT_DEPLOYED_SOURCES = getattr(settings,
@@ -35,5 +36,14 @@ PORCHLIGHT_JSON_FILE = getattr(settings,
                                'PORCHLIGHT_JSON_FILE',
                                PORCHLIGHT_JSON_FILE_DEFAULT)
 
+PORCHLIGHT_GITHUB_AUTH_DEFAULT = None
+PORCHLIGHT_GITHUB_AUTH = getattr(settings,
+                                 'PORCHLIGHT_GITHUB_AUTH',
+                                 PORCHLIGHT_GITHUB_AUTH_DEFAULT)
+
+PORCHLIGHT_GITHUB_TAG_PATTERN_DEFAULT = r'^v[.0-9]+'
+PORCHLIGHT_GITHUB_TAG_PATTERN = getattr(settings,
+                               'PORCHLIGHT_GITHUB_TAG_PATTERN',
+                               PORCHLIGHT_GITHUB_TAG_PATTERN_DEFAULT)
 
 

--- a/porchlightapi/sources/__init__.py
+++ b/porchlightapi/sources/__init__.py
@@ -5,5 +5,6 @@ from .calculators import undeployed_value_only_calculator
 from .calculators import incremental_value_calculator
 
 from .rand import random_source
-from .github import github_source
+from .github import github_commit_source
+from .github import github_tag_source
 from .json_file import json_file_source

--- a/porchlightapi/sources/github.py
+++ b/porchlightapi/sources/github.py
@@ -3,15 +3,17 @@
 from urlparse import urlparse, urlunparse
 import dateutil.parser
 import requests
+import re
 
-def github_data(project_url, branch='master', commit=''):
-    """
-    Fetch data from Github that's relevent to Porchlight.
-    This function is meant to be used by all sources that might need to
-    access Github data.
-    """
-    project_url_parts = urlparse(project_url)
+from porchlightapi.settings import PORCHLIGHT_GITHUB_AUTH
+from porchlightapi.settings import PORCHLIGHT_GITHUB_TAG_PATTERN
 
+TAG_PATTERN = re.compile(PORCHLIGHT_GITHUB_TAG_PATTERN)
+
+def github_api_url(project_url_parts):
+    """
+    Return the appropriate Github API URL for the given parsed project_url.
+    """
     # If this is a Github URL, use api.github.com. Otherwise use /api/v3/
     api_url = None
     if project_url_parts.netloc == 'github.com':
@@ -22,15 +24,63 @@ def github_data(project_url, branch='master', commit=''):
         api_url = project_url_parts._replace(
             path='/api/v3')
 
-    # Construct an API URL for the repository itself. This API call is only used
-    # to get the repo size, which is about the only metric we can get from
-    # the Github API to scale the file changes (below) relative to the
-    # repository.
+    return api_url
+
+
+def github_tag_data(project_url):
+    """
+    Fetch tag data from Github that's relevent to Porchlight.
+    This function is meant to be used by a source that uses tags to lookup
+    commit SHAs that can be passed to github_commit_data().
+    """
+
+    project_url_parts = urlparse(project_url)
+    api_url = github_api_url(project_url_parts)
+
     repo_url_parts = api_url._replace(
             path=api_url.path + '/repos' + project_url_parts.path)
     repo_url = urlunparse(repo_url_parts)
-    repo_response = requests.get(repo_url)
-    repo_size = repo_response.json()['size']
+
+    # Get all tags on the repository. We're interested in the latest tag, which
+    # is the first one in the list.
+    tags_url_parts = api_url._replace(
+        path=api_url.path + '/repos' + repo_url_parts.path + '/tags')
+    tags_url = urlunparse(tags_url_parts)
+    tags_response = requests.get(tags_url, auth=PORCHLIGHT_GITHUB_AUTH)
+    tags_response_json = tags_response.json()
+
+    # We're only interested in the latest tag that matches our tag pattern.
+    tags_matching = [t for t in tags_response_json if TAG_PATTERN.match(t['name'])]
+
+    try:
+        tag = tags_matching[0]
+    except IndexError:
+        raise ValueError("Unable to find matching tag")
+
+    return {'commit': tag['commit']['sha'],
+            'name': tag['name']}
+
+
+def github_commit_data(project_url, branch='master', commit=''):
+    """
+    Fetch commit data from Github that's relevent to Porchlight.
+    This function is meant to be used by all sources that might need to
+    access Github data.
+    """
+
+    project_url_parts = urlparse(project_url)
+    api_url = github_api_url(project_url_parts)
+
+    # Construct an API URL for the repository itself. This API call is only used
+    # to get the repo size, which is about the only metric we can get from
+    # the Github API to scale the file changes (below) relative to the
+    # reposit'}y.
+    # XXX: Commenting this out while we're not using it, to reduce one API hit
+    # repo_url_parts = api_url._replace(
+    #         path=api_url.path + '/repos' + project_url_parts.path)
+    # repo_url = urlunparse(repo_url_parts)
+    # repo_response = requests.get(repo_url, auth=PORCHLIGHT_GITHUB_AUTH)
+    # repo_size = repo_response.json()['size']
 
     # If we didn't get a specific commit, look up the branch and use that.
     commit_url = None
@@ -40,7 +90,7 @@ def github_data(project_url, branch='master', commit=''):
         branch_url_parts = api_url._replace(
             path=api_url.path + '/repos' + project_url_parts.path + '/branches/' + branch)
         branch_url = urlunparse(branch_url_parts)
-        branch_response = requests.get(branch_url)
+        branch_response = requests.get(branch_url, auth=PORCHLIGHT_GITHUB_AUTH)
 
         # Note: the branch API call above gets us *some* of the commit info, but not
         # all. We don't get files data, for example, which is important for the
@@ -52,7 +102,7 @@ def github_data(project_url, branch='master', commit=''):
             path=api_url.path + '/repos' + project_url_parts.path + '/commits/' + commit)
         commit_url = urlunparse(commit_url_parts)
 
-    commit_response = requests.get(commit_url)
+    commit_response = requests.get(commit_url, auth=PORCHLIGHT_GITHUB_AUTH)
     commit_json = commit_response.json()
     commit_num_files = len(commit_json['files'])
 
@@ -76,7 +126,7 @@ def github_data(project_url, branch='master', commit=''):
         commit_deletions = commit_deletions + file['deletions']
         commit_changes = commit_changes + file['changes']
 
-    return {'repo_size': repo_size,
+    return {# 'repo_size': repo_size,
             'commit': commit,
             'commit_num_files': commit_num_files,
             'commit_date': commit_date,
@@ -85,16 +135,47 @@ def github_data(project_url, branch='master', commit=''):
             'commit_changes': commit_changes,}
 
 
-def github_source(repository, branch='master'):
+def github_commit_source(repository, branch='master'):
     """
-    Github value source for Porchlight.
+    Github value source for the latest commit on a branch.
 
     Fetch the latest commit date, SHA, and lines from Github for the
     given project URL.
 
-    Based on Github API documentation here: https://developer.github.com/v3/git/commits/
+    Based on Github API documentation here:
+        https://developer.github.com/v3/git/commits/
     """
-    github_dict = github_data(repository.url, branch=branch)
+    github_dict = github_commit_data(repository.url, branch=branch)
+
+    # XXX: I am skeptical that this formula is useful. It includes nothing in
+    # relation to the project size, we may want to value deletions as much as
+    # additions, rather than presuming they have negative valuye, etc...
+    value = abs(github_dict['commit_additions'] - \
+                github_dict['commit_deletions'] + \
+                github_dict['commit_changes'])
+
+    return (github_dict['commit'], github_dict['commit_date'], value)
+
+
+def github_tag_source(repository):
+    """
+    Github value source for the commit associated with the most recent tag.
+
+    Fetch the latest tag, and the associated commit date, SHA, and lines
+    from Github for the given project URL.
+
+    Based on Github API documentation here:
+        https://developer.github.com/v3/git/tags/
+    """
+
+    # Get the latest tag. If a tag doesn't exist, then there is no value to be
+    # had in a tag source — this has never been deployed.
+    try:
+        github_tag_dict = github_tag_data(repository.url)
+    except ValueError:
+        return ('', None, 0)
+
+    github_dict = github_commit_data(repository.url, commit=github_tag_dict['commit'])
 
     # XXX: I am skeptical that this formula is useful. It includes nothing in
     # relation to the project size, we may want to value deletions as much as

--- a/porchlightapi/sources/github.py
+++ b/porchlightapi/sources/github.py
@@ -74,7 +74,7 @@ def github_commit_data(project_url, branch='master', commit=''):
     # Construct an API URL for the repository itself. This API call is only used
     # to get the repo size, which is about the only metric we can get from
     # the Github API to scale the file changes (below) relative to the
-    # reposit'}y.
+    # repository.
     # XXX: Commenting this out while we're not using it, to reduce one API hit
     # repo_url_parts = api_url._replace(
     #         path=api_url.path + '/repos' + project_url_parts.path)

--- a/porchlightapi/sources/json_file.py
+++ b/porchlightapi/sources/json_file.py
@@ -6,7 +6,7 @@ import json
 import dateutil.parser
 
 from porchlightapi import settings
-from .github import github_data
+from .github import github_commit_data
 
 def json_file_source(repository):
     """
@@ -34,7 +34,7 @@ def json_file_source(repository):
     date = dateutil.parser.parse(date_string)
 
     # Lookup the data in Github
-    github_dict = github_data(repository.url, commit=commit)
+    github_dict = github_commit_data(repository.url, commit=commit)
 
     # XXX: I am skeptical that this formula is useful. It includes nothing in
     # relation to the project size, we may want to value deletions as much as

--- a/porchlightapi/tests.py
+++ b/porchlightapi/tests.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 from django.test import TestCase
 import mock
 
@@ -130,11 +129,11 @@ class GithubDataSourceTestCase(TestCase):
         Set up the mock request responses for Github.
         """
 
-        # First call, to /repos/porchlight is only interested in size
+        # Call to /repos/porchlight is only interested in size
         self.mock_repo_response = mock.MagicMock()
         self.mock_repo_response.json.return_value = {u'size': 1619,}
 
-        # Second call to /repos/porchlight/branches/master is used to
+        # Call to /repos/porchlight/branches/master is used to
         # get last commit SHA and URL
         self.mock_branches_response = mock.MagicMock()
         self.mock_branches_response.json.return_value = {u'commit':
@@ -142,8 +141,8 @@ class GithubDataSourceTestCase(TestCase):
                  u'url': u'https://api.github.com/repos/cfpb/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441'}
             }
 
-        # Second call to /repos/porchlight/branches/master is used to
-        # get last commit SHA and URL
+        # Call to /repos/porchlight/tags is used to get latest commit SHA and
+        # tag name
         self.mock_tags_response = mock.MagicMock()
         self.mock_tags_response.json.return_value = [{
                 u'commit':{u'sha':u'130df1874519c11a79ac4a2e3e6671a165860441'},
@@ -155,7 +154,7 @@ class GithubDataSourceTestCase(TestCase):
                 u'name':u'atag'
             },]
 
-        # Third call is to the commit itself, /repos/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441
+        # Call to the commit itself /repos/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441
         # is used to get the date and file data
         self.mock_commit_response = mock.MagicMock()
         self.mock_commit_response.json.return_value = {

--- a/porchlightapi/tests.py
+++ b/porchlightapi/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import unittest
 from django.test import TestCase
 import mock
 
@@ -118,10 +119,11 @@ class ValueDataPointManagerTestCase(TestCase):
 ## Test Data Sources
 
 import datetime
-from porchlightapi.sources import github_source
+from porchlightapi.sources import github_commit_source
+from porchlightapi.sources import github_tag_source
 from porchlightapi.sources import json_file_source
 
-class DataSourceTestCase(TestCase):
+class GithubDataSourceTestCase(TestCase):
 
     def setUp(self):
         """
@@ -140,6 +142,19 @@ class DataSourceTestCase(TestCase):
                  u'url': u'https://api.github.com/repos/cfpb/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441'}
             }
 
+        # Second call to /repos/porchlight/branches/master is used to
+        # get last commit SHA and URL
+        self.mock_tags_response = mock.MagicMock()
+        self.mock_tags_response.json.return_value = [{
+                u'commit':{u'sha':u'130df1874519c11a79ac4a2e3e6671a165860441'},
+                u'name':u'v0.1.0'
+            },]
+        self.mock_no_tags_response = mock.MagicMock()
+        self.mock_no_tags_response.json.return_value = [{
+                u'commit':{u'sha':u'130df1874519c11a79ac4a2e3e6671a165860441'},
+                u'name':u'atag'
+            },]
+
         # Third call is to the commit itself, /repos/porchlight/commits/130df1874519c11a79ac4a2e3e6671a165860441
         # is used to get the date and file data
         self.mock_commit_response = mock.MagicMock()
@@ -156,19 +171,21 @@ class DataSourceTestCase(TestCase):
         self.mock_repository = mock.create_autospec(Repository)
         self.mock_repository.url = 'https://github.com/cfpb/porchlight'
 
-
     @mock.patch("requests.get")
-    def test_github_source(self, mock_request_get):
+    def test_github_commit_source(self, mock_request_get):
         # Test that our Github source function correctly constructs URLs by
         # mocking requests.get()
-
+        # There should be 3 calls to request.get(), one for the repository (to
+        # get size), one for branches, and one for commits.
+        # XXX: Because we're not using the repo size, it's been commented out to
+        # reduce API hits.
         mock_request_get.side_effect = [
-            self.mock_repo_response,
+            # self.mock_repo_response,
             self.mock_branches_response,
             self.mock_commit_response
         ]
 
-        source_tuple = github_source(self.mock_repository)
+        source_tuple = github_commit_source(self.mock_repository)
 
         test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
                                       minute=44, second=20, tzinfo=tz.tzutc())
@@ -176,6 +193,39 @@ class DataSourceTestCase(TestCase):
         self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
         self.assertEqual(source_tuple[1], test_date)
         self.assertEqual(source_tuple[2], 15)
+
+    @mock.patch("requests.get")
+    def test_github_tag_source(self, mock_request_get):
+        # Test that our Github source function correctly constructs URLs by
+        # mocking requests.get().
+        # For tags there should be two calls to request.get(), one for tags and
+        # then one for the commit for the tag we're interested in.
+        mock_request_get.side_effect = [
+            self.mock_tags_response,
+            self.mock_commit_response
+        ]
+
+        source_tuple = github_tag_source(self.mock_repository)
+
+        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
+                                      minute=44, second=20, tzinfo=tz.tzutc())
+
+        self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
+        self.assertEqual(source_tuple[1], test_date)
+        self.assertEqual(source_tuple[2], 15)
+
+        # Now test that if there is no tag that matches our pattern that we
+        # return as close to a 'no-value' as we can.
+
+        mock_request_get.side_effect = [
+            self.mock_no_tags_response,
+            self.mock_commit_response
+        ]
+
+        source_tuple = github_tag_source(self.mock_repository)
+        self.assertEqual(source_tuple[0], '')
+        self.assertEqual(source_tuple[1], None)
+        self.assertEqual(source_tuple[2], 0)
 
 
     @mock.patch("__builtin__.open")
@@ -194,10 +244,10 @@ class DataSourceTestCase(TestCase):
                                         u'date': u'Mon Jan 26 21:44:20 UTC 2015'},]
 
         # Mock the requests.get() calls to github API. This differs from
-        # github_source() above because we get the commit SHA from the
+        # github_commit_source() above because we get the commit SHA from the
         # json data rather than from the tip of a branch.
         mock_request_get.side_effect = [
-            self.mock_repo_response,
+            # self.mock_repo_response,
             self.mock_commit_response
         ]
 

--- a/porchlightapi/tests.py
+++ b/porchlightapi/tests.py
@@ -166,6 +166,9 @@ class GithubDataSourceTestCase(TestCase):
             ]
         }
 
+        self.test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
+                                      minute=44, second=20, tzinfo=tz.tzutc())
+
         # A mock repository with a URL
         self.mock_repository = mock.create_autospec(Repository)
         self.mock_repository.url = 'https://github.com/cfpb/porchlight'
@@ -186,11 +189,8 @@ class GithubDataSourceTestCase(TestCase):
 
         source_tuple = github_commit_source(self.mock_repository)
 
-        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
-                                      minute=44, second=20, tzinfo=tz.tzutc())
-
         self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
-        self.assertEqual(source_tuple[1], test_date)
+        self.assertEqual(source_tuple[1], self.test_date)
         self.assertEqual(source_tuple[2], 15)
 
     @mock.patch("requests.get")
@@ -206,11 +206,8 @@ class GithubDataSourceTestCase(TestCase):
 
         source_tuple = github_tag_source(self.mock_repository)
 
-        test_date = datetime.datetime(year=2015, month=01, day=26, hour=21,
-                                      minute=44, second=20, tzinfo=tz.tzutc())
-
         self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
-        self.assertEqual(source_tuple[1], test_date)
+        self.assertEqual(source_tuple[1], self.test_date)
         self.assertEqual(source_tuple[2], 15)
 
         # Now test that if there is no tag that matches our pattern that we
@@ -253,7 +250,7 @@ class GithubDataSourceTestCase(TestCase):
         source_tuple = json_file_source(self.mock_repository)
 
         self.assertEqual(source_tuple[0], '130df1874519c11a79ac4a2e3e6671a165860441')
-        self.assertEqual(source_tuple[1], test_date)
+        self.assertEqual(source_tuple[1], self.test_date)
         self.assertEqual(source_tuple[2], 15)
 
 

--- a/sample-data/link_header.py
+++ b/sample-data/link_header.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+"""
+HTTP Link Header Parsing
+
+Simple routines to parse and manipulate Link headers.
+"""
+
+__license__ = """
+Copyright (c) 2009 Mark Nottingham
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import re
+
+TOKEN = r'(?:[^\(\)<>@,;:\\"/\[\]\?={} \t]+?)'
+QUOTED_STRING = r'(?:"(?:\\"|[^"])*")'
+PARAMETER = r'(?:%(TOKEN)s(?:=(?:%(TOKEN)s|%(QUOTED_STRING)s))?)' % locals()
+LINK = r'<[^>]*>\s*(?:;\s*%(PARAMETER)s?\s*)*' % locals()
+COMMA = r'(?:\s*(?:,\s*)+)'
+LINK_SPLIT = r'%s(?=%s|\s*$)' % (LINK, COMMA)
+
+def _unquotestring(instr):
+    if instr[0] == instr[-1] == '"':
+        instr = instr[1:-1]
+        instr = re.sub(r'\\(.)', r'\1', instr)
+    return instr
+def _splitstring(instr, item, split):
+    if not instr: 
+        return []
+    return [ h.strip() for h in re.findall(r'%s(?=%s|\s*$)' % (item, split), instr)]
+
+link_splitter = re.compile(LINK_SPLIT)
+
+def parse_link_value(instr):
+	"""
+	Given a link-value (i.e., after separating the header-value on commas), 
+	return a dictionary whose keys are link URLs and values are dictionaries
+	of the parameters for their associated links.
+	
+	Note that internationalised parameters (e.g., title*) are 
+	NOT percent-decoded.
+	
+	Also, only the last instance of a given parameter will be included.
+	
+	For example, 
+	
+	>>> parse_link_value('</foo>; rel="self"; title*=utf-8\'de\'letztes%20Kapitel')
+	{'/foo': {'title*': "utf-8'de'letztes%20Kapitel", 'rel': 'self'}}
+	
+	"""
+	out = {}
+	if not instr: 
+		return out
+	for link in [h.strip() for h in link_splitter.findall(instr)]:
+		url, params = link.split(">", 1)
+		url = url[1:]
+		param_dict = {}
+		for param in _splitstring(params, PARAMETER, "\s*;\s*"):
+			try:
+				a, v = param.split("=", 1)
+				param_dict[a.lower()] = _unquotestring(v)
+			except ValueError:
+				param_dict[param.lower()] = None
+		out[url] = param_dict
+	return out
+	
+	
+if __name__ == '__main__':
+	import sys
+	if len(sys.argv) > 1:
+		print parse_link_value(sys.argv[1])

--- a/sample-data/sample_data.py
+++ b/sample-data/sample_data.py
@@ -1,0 +1,257 @@
+
+from urlparse import urlparse, urlunparse
+import requests
+import dateutil.parser
+import pickle
+import os.path
+import datetime
+import json
+from dateutil import tz
+
+import link_header
+
+AUTH=('willbarton', 'f763a270c2dc0cf6968d39a4f5b45fcc78a11a60')
+
+def date_handler(obj):
+    return obj.isoformat() if hasattr(obj, 'isoformat') else obj
+
+def github_api_all(url):
+    """
+    Fetch all results, not simply the first page of results, for the given URL.
+    """
+
+    # Get our initial response
+    response = requests.get(url, auth=AUTH)
+    response_json = response.json()
+
+    # Parse the links header
+    parsed_links = link_header.parse_link_value(response.headers['link'])
+    links = dict([(parsed_links[l]['rel'], l) for l in parsed_links])
+    while 'next' in links:
+        # While we have a 'next' link, fetch it and add its response to the json
+        # object.
+        page_response = requests.get(links['next'], auth=AUTH)
+        response_json += page_response.json()
+
+        parsed_links = link_header.parse_link_value(page_response.headers['link'])
+        links = dict([(parsed_links[l]['rel'], l) for l in parsed_links])
+
+    return response_json
+
+def github_data(repo_url, branch='master', commit=''):
+    """
+    Fetch data from Github that's relevent to Porchlight.
+    This function is meant to be used by all sources that might need to
+    access Github data.
+    """
+    repo_url_parts = urlparse(repo_url)
+
+    # If this is a Github URL, use api.github.com. Otherwise use /api/v3/
+    api_url = None
+    if repo_url_parts.netloc == 'github.com':
+        api_url = repo_url_parts._replace(
+            netloc='api.' + repo_url_parts.netloc,
+            path='')
+    else:
+        api_url = repo_url_parts._replace(
+            path='/api/v3')
+
+    # Construct an API URL for the repository itself. This API call is only used
+    # to get the repo size, which is about the only metric we can get from
+    # the Github API to scale the file changes (below) relative to the
+    # repository.
+    repo_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + repo_url_parts.path)
+    repo_url = urlunparse(repo_url_parts)
+    repo_response = requests.get(repo_url, auth=AUTH)
+    repo_size = repo_response.json()['size']
+
+    # If we didn't get a specific commit, look up the branch and use that.
+    commit_url = None
+    if commit == '':
+        # Get the specified branch so we can lookup the latest commit SHA.
+        # We'll construct an API URL based on the project URL.
+        branch_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + repo_url_parts.path + '/branches/' + branch)
+        branch_url = urlunparse(branch_url_parts)
+        branch_response = requests.get(branch_url, auth=AUTH)
+
+        # Note: the branch API call above gets us *some* of the commit info, but not
+        # all. We don't get files data, for example, which is important for the
+        # value calculation below.
+        commit = branch_response.json()['commit']['sha']
+        commit_url = branch_response.json()['commit']['url']
+    else:
+        commit_url_parts = api_url._replace(
+            path=api_url.path + repo_url_parts.path + '/commits/' + commit)
+        commit_url = urlunparse(commit_url_parts)
+
+    commit_response = requests.get(commit_url, auth=AUTH)
+    commit_json = commit_response.json()
+
+    commit_num_files = len(commit_json['files'])
+
+    # Pyhton date formatting doesn't give any good option for parsing ISO-8601
+    # dates that include a 'Z' (Zulu) for UTC instead of simply +0000. According
+    # to the Github API documentation, Github returns ISO-8601 with the full
+    # timezone offset. However, the results I'm seeing from Github all represent
+    # the timezone as 'Z'. To be safe, not make assumptions, and not add
+    # unnecessary complexity, `dateutil.parser` is being used to parse date
+    # strings.
+    commit_date_string = commit_json['commit']['committer']['date']
+    commit_date = dateutil.parser.parse(commit_date_string)
+
+    # This is the useful information to us about how valuable this commit might
+    # be. This is used below in the value calcualtion.
+    commit_additions = 0
+    commit_deletions = 0
+    commit_changes = 0
+    for file in commit_json['files']:
+        commit_additions = commit_additions + file['additions']
+        commit_deletions = commit_deletions + file['deletions']
+        commit_changes = commit_changes + file['changes']
+
+    return {'repo_size': repo_size,
+            'commit': commit,
+            'commit_num_files': commit_num_files,
+            'commit_date': commit_date,
+            'commit_additions': commit_additions,
+            'commit_deletions': commit_deletions,
+            'commit_changes': commit_changes,}
+
+
+
+def sample_repo(sample_data, pk, repo_url, name, project=""):
+    print "Sampling " + repo_url
+
+    # Append this repository to our sample data.
+    sample_data.append({
+        "fields": {
+            "name": name,
+            "url": repo_url,
+            "project": project,
+            "undeployed_value_source": "porchlightapi.sources.github_source",
+            "value_calculator": "porchlightapi.sources.incremental_value_calculator",
+            "deployed_value_source": "porchlightapi.sources.json_file_source"
+        },
+        "model": "porchlightapi.repository",
+        "pk": pk
+    })
+
+
+    # (1) Get data for the commit
+    repo_url_parts = urlparse(repo_url)
+
+    api_url = None
+    if repo_url_parts.netloc == 'github.com':
+        api_url = repo_url_parts._replace(
+            netloc='api.' + repo_url_parts.netloc,
+            path='')
+    else:
+        api_url = repo_url_parts._replace(
+            path='/api/v3')
+
+    # Use a file to store the data so we don't hit rate limits
+    commit_data = []
+    if os.path.isfile(str(pk) + '_commit_data.pickle'):
+        print repo_url + " Commit Data is already pickled"
+        commit_data = pickle.load(open(str(pk) + '_commit_data.pickle'))
+    else:
+        repo_url_parts = urlparse(repo_url)
+
+        api_url = None
+        if repo_url_parts.netloc == 'github.com':
+            api_url = repo_url_parts._replace(
+                netloc='api.' + repo_url_parts.netloc,
+                path='')
+        else:
+            api_url = repo_url_parts._replace(
+                path='/api/v3')
+
+        # For each commit in the repository:
+        commits_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + repo_url_parts.path + '/commits')
+        commits_url = urlunparse(commits_url_parts)
+
+        # commits_response = requests.get(commits_url, auth=AUTH)
+        # commits_response_json = commits_response.json()
+
+        #  Get paginated commits
+        commits_response_json = github_api_all(commits_url)
+
+        commits_list = [c['sha'] for c in commits_response_json]
+        commit_data = [github_data(repo_url, commit=c) for c in commits_list]
+
+        commit_data.sort(key=lambda item:item['commit_date'], reverse=False)
+        pickle.dump(commit_data, open(str(pk) + '_commit_data.pickle', 'wb'))
+
+    # (2) Get all tags on the repository.
+    tag_data = []
+    if os.path.isfile(str(pk) + '_tag_data.pickle'):
+        print repo_url + " Tag Data is already pickled"
+        tag_data = pickle.load(open(str(pk) + '_tag_data.pickle'))
+    else:
+        # For each commit in the repository:
+        tags_url_parts = api_url._replace(
+            path=api_url.path + '/repos' + repo_url_parts.path + '/tags')
+        tags_url = urlunparse(tags_url_parts)
+        tags_response = requests.get(tags_url, auth=AUTH)
+        tags_response_json = tags_response.json()
+        tag_data = dict([(t['commit']['sha'], t['name']) for t in tags_response_json if t['name'].startswith('v')])
+
+        pickle.dump(tag_data, open(str(pk) + '_tag_data.pickle', 'wb'))
+
+    # Sort the commits by date descending.
+
+    # (3) See what the date delta is between tag commits and commits themselves.
+    value = 0
+    d = datetime.datetime.fromtimestamp(0)
+    d = d.replace(tzinfo=tz.tzutc())
+    c = datetime.datetime.now()
+    c = c.replace(tzinfo=tz.tzutc())
+    last_deployed_commit = {'commit': '', 'commit_date': d}
+    for commit in commit_data:
+        # See if the commit is tagged
+        if commit['commit'] in tag_data:
+            # If so, the value goes to 0.
+            last_deployed_commit = commit
+            value = 0
+        else:
+            # Otherwise, increment it
+            value += abs(commit['commit_additions'] - \
+                         commit['commit_deletions'] + \
+                         commit['commit_changes'])
+
+        # c_pk = commit_data.index(commit)
+
+        # github_dict['commit'], github_dict['commit_date'], value
+
+        sample_data.append({
+                "fields": {
+                    "repository": pk,
+                    "deployed_identifier": last_deployed_commit['commit'],
+                    "undeployed_value": value,
+                    "deployed_value": 0,
+                    "created": commit['commit_date'].isoformat(),
+                    "undeployed_identifier": commit['commit'],
+                    "value": value,
+                    "undeployed_datetime": commit['commit_date'].isoformat(),
+                    # "deployed_datetime": last_deployed_commit['commit_date'].isoformat(),
+                },
+                "model": "porchlightapi.valuedatapoint",
+            })
+
+
+
+
+if __name__ == "__main__":
+    sample_data = []
+    sample_repo(sample_data, 1, 'https://github.com/cfpb/owning-a-home-api', 'OAH-API', 'Owning a Home')
+    sample_repo(sample_data, 2, 'https://github.com/cfpb/owning-a-home', 'Owning a Home', 'Owning a Home')
+    sample_repo(sample_data, 3, 'https://github.com/cfpb/cms-toolkit', 'WordPress CMS Toolkit', 'CF.gov')
+    sample_repo(sample_data, 4, 'https://github.com/cfpb/wp-json-api', 'WordPress JSON API', 'CF.gov')
+    sample_repo(sample_data, 5, 'https://github.com/cfpb/regulations-core', 'regulations-core', 'eRegulations')
+    # sample_repo(sample_data, 6, 'https://github.com/cfpb/mapusaurus', 'Mapusaurus', 'Fair Lending')
+
+    json.dump(sample_data, open('data.json', 'w'), indent=4)
+

--- a/sample-data/sample_data.py
+++ b/sample-data/sample_data.py
@@ -10,7 +10,7 @@ from dateutil import tz
 
 import link_header
 
-AUTH=('willbarton', 'f763a270c2dc0cf6968d39a4f5b45fcc78a11a60')
+AUTH=('', '')
 
 def date_handler(obj):
     return obj.isoformat() if hasattr(obj, 'isoformat') else obj


### PR DESCRIPTION
This PR adds a Github Tags deployed value source that will pull in the latest Github tag for a repository whose name matches a regular expression (`^v[.0-9]+` by default) and use that tag's commit as the basis for the deployed value.

**Additions**
- Added `github_tag_source()` and tests
- Added `PORCHLIGHT_GITHUB_TAG_PATTERN` setting
- Added `PORCHLIGHT_GITHUB_AUTH` setting

**Changes**
- Changed `github_source` to `github_commit_source`

**Review**
- @Ooblioob 
- @sebworks 

**Notes**
- The existing Github source, `github_source` was changed to `github_commit_source`, so any existing Repositories that use it will need to have their value sources changed.
- This PR supersedes https://github.com/cfpb/porchlight/pull/28
