### PR TITLE
PR of Shame to move SECRET_KEY to local_settings_template.py

### DIFF
--- a/porchlight/local_settings_template.py
+++ b/porchlight/local_settings_template.py
@@ -1,4 +1,6 @@
 
+DEBUG = True
+TEMPLATE_DEBUG = True
 
 # Secret key should live in your local settings.py and should be unique.
 SECRET_KEY = 'sssh-make-this-unique'

--- a/porchlight/local_settings_template.py
+++ b/porchlight/local_settings_template.py
@@ -1,5 +1,7 @@
 
 
+# Secret key should live in your local settings.py and should be unique.
+SECRET_KEY = 'sssh-make-this-unique'
 
 # Set this if you want to load a JSON file from a specific path.
 PORCHLIGHT_JSON_FILE = ''

--- a/porchlight/settings.py
+++ b/porchlight/settings.py
@@ -16,10 +16,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = []
 

--- a/porchlight/settings.py
+++ b/porchlight/settings.py
@@ -16,9 +16,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '+=(&43(kf^2t6r6m%=cez^k+y^o(@vv&d+-t2)%2lcn__y_hf_'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
Thanks to @laminfaty for spotting this. This fixes issue #32.

The `SECRET_KEY` setting should live in `local_settings.py`, for which we provide a template, `local_settings_template.py`. This removes the auto-generated secret key from `settings.py`.
